### PR TITLE
Work around MSVC conformance bug

### DIFF
--- a/include/llfio/v2.0/async_file_handle.hpp
+++ b/include/llfio/v2.0/async_file_handle.hpp
@@ -385,7 +385,7 @@ public:
     struct completion_handler : _erased_completion_handler
     {
       CompletionRoutine completion;
-      explicit completion_handler(CompletionRoutine c)
+      completion_handler(CompletionRoutine c)
           : completion(std::move(c))
       {
       }
@@ -440,7 +440,7 @@ public:
     struct completion_handler : _erased_completion_handler
     {
       CompletionRoutine completion;
-      explicit completion_handler(CompletionRoutine c)
+      completion_handler(CompletionRoutine c)
           : completion(std::move(c))
       {
       }
@@ -483,7 +483,7 @@ public:
     struct completion_handler : _erased_completion_handler
     {
       CompletionRoutine completion;
-      explicit completion_handler(CompletionRoutine c)
+      completion_handler(CompletionRoutine c)
           : completion(std::move(c))
       {
       }


### PR DESCRIPTION
MSVC chokes in `/permissive-` mode on explicit constructors taking
template arguments from the outer scope. Fixes #24 