### PR TITLE
Fixed cache alignment calculation in barrier function

### DIFF
--- a/include/llfio/v2.0/map_handle.hpp
+++ b/include/llfio/v2.0/map_handle.hpp
@@ -448,8 +448,8 @@ public:
   LLFIO_MAKE_FREE_FUNCTION
   static const_buffer_type barrier(const_buffer_type req, bool evict = false) noexcept
   {
-    auto *tp = (const_buffer_type::pointer)(((uintptr_t) req.data()) & 63);
-    const_buffer_type ret{tp, (size_t)(req.data() + req.size() - tp)};
+    auto *tp = (const_buffer_type::pointer)(((uintptr_t) req.data()) & ~63);
+    const_buffer_type ret{tp, (size_t)((req.data() + req.size() + 63 - tp)&(~63))};
     if(memory_flush_none == mem_flush_stores(ret.data(), ret.size(), evict ? memory_flush_evict : memory_flush_retain))
     {
       ret = {tp, 0};


### PR DESCRIPTION
The calculation of cache alignment in barrier function was incorrect.

Note: The same cache alignment calculation is also done in function `mem_flush_stores`. The code could be optimized so it is done only once.