### PR TITLE
Use unicode Win32 API explicitly everywhere

### DIFF
--- a/include/llfio/v2.0/config.hpp
+++ b/include/llfio/v2.0/config.hpp
@@ -87,9 +87,6 @@ Distributed under the Boost Software License, Version 1.0.
 
 
 #if defined(_WIN32)
-#if !defined(_UNICODE)
-#error LLFIO cannot target the ANSI Windows API. Please define _UNICODE to target the Unicode Windows API.
-#endif
 #if !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0600
 #elif _WIN32_WINNT < 0x0600

--- a/include/llfio/v2.0/detail/impl/windows/handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/handle.ipp
@@ -51,7 +51,7 @@ result<handle::path_type> handle::current_path() const noexcept
     buffer.resize(32769);
     auto *_buffer = const_cast<wchar_t *>(buffer.data());
     memcpy(_buffer, L"\\!!", 6);
-    DWORD len = GetFinalPathNameByHandle(_v.h, _buffer + 3, (DWORD)(buffer.size() - 4 * sizeof(wchar_t)), VOLUME_NAME_NT);  // NOLINT
+    DWORD len = GetFinalPathNameByHandleW(_v.h, _buffer + 3, (DWORD)(buffer.size() - 4 * sizeof(wchar_t)), VOLUME_NAME_NT);  // NOLINT
     if(len == 0)
     {
       return win32_error();

--- a/include/llfio/v2.0/detail/impl/windows/import.hpp
+++ b/include/llfio/v2.0/detail/impl/windows/import.hpp
@@ -245,9 +245,9 @@ namespace windows_nt_kernel
     DWORD SizeOfStruct;
     PVOID Key;
     DWORD LineNumber;
-    PTSTR FileName;
+    PWSTR FileName;
     DWORD64 Address;
-  } IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
+  } IMAGEHLP_LINEW64, *PIMAGEHLP_LINEW64;
 
   typedef enum _SECTION_INHERIT
   {
@@ -359,7 +359,7 @@ namespace windows_nt_kernel
 
   using OpenProcessToken_t = BOOL(NTAPI *)(_In_ HANDLE ProcessHandle, _In_ DWORD DesiredAccess, _Out_ PHANDLE TokenHandle);
 
-  using LookupPrivilegeValue_t = BOOL(NTAPI *)(_In_opt_ LPCTSTR lpSystemName, _In_ LPCTSTR lpName, _Out_ PLUID lpLuid);
+  using LookupPrivilegeValue_t = BOOL(NTAPI *)(_In_opt_ LPCWSTR lpSystemName, _In_ LPCWSTR lpName, _Out_ PLUID lpLuid);
 
   using AdjustTokenPrivileges_t = BOOL(NTAPI *)(_In_ HANDLE TokenHandle, _In_ BOOL DisableAllPrivileges, _In_opt_ PTOKEN_PRIVILEGES NewState, _In_ DWORD BufferLength, _Out_opt_ PTOKEN_PRIVILEGES PreviousState, _Out_opt_ PDWORD ReturnLength);
 
@@ -369,9 +369,9 @@ namespace windows_nt_kernel
 
   using RtlCaptureStackBackTrace_t = USHORT(NTAPI *)(_In_ ULONG FramesToSkip, _In_ ULONG FramesToCapture, _Out_ PVOID *BackTrace, _Out_opt_ PULONG BackTraceHash);
 
-  using SymInitialize_t = BOOL(NTAPI *)(_In_ HANDLE hProcess, _In_opt_ PCTSTR UserSearchPath, _In_ BOOL fInvadeProcess);
+  using SymInitialize_t = BOOL(NTAPI *)(_In_ HANDLE hProcess, _In_opt_ PCWSTR UserSearchPath, _In_ BOOL fInvadeProcess);
 
-  using SymGetLineFromAddr64_t = BOOL(NTAPI *)(_In_ HANDLE hProcess, _In_ DWORD64 dwAddr, _Out_ PDWORD pdwDisplacement, _Out_ PIMAGEHLP_LINE64 Line);
+  using SymGetLineFromAddr64_t = BOOL(NTAPI *)(_In_ HANDLE hProcess, _In_ DWORD64 dwAddr, _Out_ PDWORD pdwDisplacement, _Out_ PIMAGEHLP_LINEW64 Line);
 
   using RtlDosPathNameToNtPathName_U_t = BOOLEAN(NTAPI *)(__in PCWSTR DosFileName, __out PUNICODE_STRING NtFileName, __out_opt PWSTR *FilePart, __out_opt PVOID RelativeName);
 
@@ -1553,7 +1553,7 @@ not replace the inode if it already exists. We map it correctly to FILE_SUPERSED
 This edition does pretty much the same as the Win32 edition, minus support for file
 templates and lpFileName being anything but a file path.
 */
-inline HANDLE CreateFileW_(_In_ LPCTSTR lpFileName, _In_ DWORD dwDesiredAccess, _In_ DWORD dwShareMode, _In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes, _In_ DWORD dwCreationDisposition, _In_ DWORD dwFlagsAndAttributes, _In_opt_ HANDLE hTemplateFile, bool forcedir = false)
+inline HANDLE CreateFileW_(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess, _In_ DWORD dwShareMode, _In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes, _In_ DWORD dwCreationDisposition, _In_ DWORD dwFlagsAndAttributes, _In_opt_ HANDLE hTemplateFile, bool forcedir = false)
 {
   windows_nt_kernel::init();
   using namespace windows_nt_kernel;

--- a/include/llfio/v2.0/detail/impl/windows/map_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/map_handle.ipp
@@ -130,7 +130,7 @@ result<section_handle> section_handle::section(file_handle &backing, extent_type
     DWORD sessionid = 0;
     if(ProcessIdToSessionId(GetCurrentProcessId(), &sessionid) != 0)
     {
-      wsprintf(buffer_, L"\\Sessions\\%u\\BaseNamedObjects\\", sessionid);
+      wsprintfW(buffer_, L"\\Sessions\\%u\\BaseNamedObjects\\", sessionid);
     }
     return buffer_;
   }();

--- a/include/llfio/v2.0/detail/impl/windows/path_discovery.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/path_discovery.ipp
@@ -48,7 +48,7 @@ namespace path_discovery
       for(auto &variable : variables)
       {
         buffer.resize(32768);
-        DWORD len = GetEnvironmentVariable(variable, const_cast<LPWSTR>(buffer.data()), static_cast<DWORD>(buffer.size()));
+        DWORD len = GetEnvironmentVariableW(variable, const_cast<LPWSTR>(buffer.data()), static_cast<DWORD>(buffer.size()));
         if((len != 0u) && len < buffer.size())
         {
           buffer.resize(len);
@@ -102,7 +102,7 @@ namespace path_discovery
     // fall back to Win3.1 era "the Windows directory" which definitely won't be
     // C:\Windows nowadays
     buffer.resize(32768);
-    DWORD len = GetWindowsDirectory(const_cast<LPWSTR>(buffer.data()), static_cast<UINT>(buffer.size()));
+    DWORD len = GetWindowsDirectoryW(const_cast<LPWSTR>(buffer.data()), static_cast<UINT>(buffer.size()));
     if((len != 0u) && len < buffer.size())
     {
       buffer.resize(len);
@@ -111,7 +111,7 @@ namespace path_discovery
     }
     // And if even that fails, try good old %SYSTEMDRIVE%\Temp
     buffer.resize(32768);
-    len = GetSystemWindowsDirectory(const_cast<LPWSTR>(buffer.data()), static_cast<UINT>(buffer.size()));
+    len = GetSystemWindowsDirectoryW(const_cast<LPWSTR>(buffer.data()), static_cast<UINT>(buffer.size()));
     if((len != 0u) && len < buffer.size())
     {
       buffer.resize(len);

--- a/include/llfio/v2.0/detail/impl/windows/stat.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/stat.ipp
@@ -120,7 +120,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> stat_t::fill(const handle &h, sta
   {
     // This is a bit hacky, but we just need a unique device number
     alignas(8) wchar_t buffer_[32769];
-    DWORD len = GetFinalPathNameByHandle(h.native_handle().h, buffer_, sizeof(buffer_) / sizeof(*buffer_), VOLUME_NAME_NT);
+    DWORD len = GetFinalPathNameByHandleW(h.native_handle().h, buffer_, sizeof(buffer_) / sizeof(*buffer_), VOLUME_NAME_NT);
     if((len == 0u) || len >= sizeof(buffer_) / sizeof(*buffer_))
     {
       return win32_error();

--- a/include/llfio/v2.0/detail/impl/windows/statfs.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/statfs.ipp
@@ -147,7 +147,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
     alignas(8) wchar_t buffer2[32769];
     for(;;)
     {
-      DWORD pathlen = GetFinalPathNameByHandle(h.native_handle().h, buffer2, sizeof(buffer2) / sizeof(*buffer2), FILE_NAME_OPENED | VOLUME_NAME_NONE);
+      DWORD pathlen = GetFinalPathNameByHandleW(h.native_handle().h, buffer2, sizeof(buffer2) / sizeof(*buffer2), FILE_NAME_OPENED | VOLUME_NAME_NONE);
       if((pathlen == 0u) || pathlen >= sizeof(buffer2) / sizeof(*buffer2))
       {
         return win32_error();
@@ -155,7 +155,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
       buffer2[pathlen] = 0;
       if(wanted & want::mntfromname)
       {
-        DWORD len = GetFinalPathNameByHandle(h.native_handle().h, buffer, sizeof(buffer) / sizeof(*buffer), FILE_NAME_OPENED | VOLUME_NAME_NT);
+        DWORD len = GetFinalPathNameByHandleW(h.native_handle().h, buffer, sizeof(buffer) / sizeof(*buffer), FILE_NAME_OPENED | VOLUME_NAME_NT);
         if((len == 0u) || len >= sizeof(buffer) / sizeof(*buffer))
         {
           return win32_error();
@@ -182,7 +182,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
       }
       if(wanted & want::mntonname)
       {
-        DWORD len = GetFinalPathNameByHandle(h.native_handle().h, buffer, sizeof(buffer) / sizeof(*buffer), FILE_NAME_OPENED | VOLUME_NAME_DOS);
+        DWORD len = GetFinalPathNameByHandleW(h.native_handle().h, buffer, sizeof(buffer) / sizeof(*buffer), FILE_NAME_OPENED | VOLUME_NAME_DOS);
         if((len == 0u) || len >= sizeof(buffer) / sizeof(*buffer))
         {
           return win32_error();

--- a/include/llfio/v2.0/detail/impl/windows/storage_profile.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/storage_profile.ipp
@@ -63,7 +63,7 @@ namespace storage_profile
           static RtlGetVersion_t RtlGetVersion;
           if(RtlGetVersion == nullptr)
           {
-            RtlGetVersion = reinterpret_cast<RtlGetVersion_t>(GetProcAddress(GetModuleHandle(L"NTDLL.DLL"), "RtlGetVersion"));
+            RtlGetVersion = reinterpret_cast<RtlGetVersion_t>(GetProcAddress(GetModuleHandleW(L"NTDLL.DLL"), "RtlGetVersion"));
           }
           if(RtlGetVersion == nullptr)
           {

--- a/include/llfio/v2.0/detail/impl/windows/symlink_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/symlink_handle.ipp
@@ -59,7 +59,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<symlink_handle> symlink_handle::symlink(c
       if(OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &token))
       {
         TOKEN_PRIVILEGES privs = {1};
-        if(LookupPrivilegeValue(NULL, SE_CREATE_SYMBOLIC_LINK_NAME, &privs.Privileges[0].Luid))
+        if(LookupPrivilegeValueW(NULL, L"SeCreateSymbolicLinkPrivilege", &privs.Privileges[0].Luid))
         {
           privs.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
           if(AdjustTokenPrivileges(token, FALSE, &privs, 0, NULL, NULL) && GetLastError() == S_OK)

--- a/include/llfio/v2.0/detail/impl/windows/utils.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/utils.ipp
@@ -79,7 +79,7 @@ namespace utils
           TOKEN_PRIVILEGES privs{};
           memset(&privs, 0, sizeof(privs));
           privs.PrivilegeCount = 1;
-          if(LookupPrivilegeValue(nullptr, SE_LOCK_MEMORY_NAME, &privs.Privileges[0].Luid))
+          if(LookupPrivilegeValueW(nullptr, L"SeLockMemoryPrivilege", &privs.Privileges[0].Luid))
           {
             privs.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
             if((AdjustTokenPrivileges(token, FALSE, &privs, 0, nullptr, nullptr) != 0) && GetLastError() == S_OK)
@@ -122,7 +122,7 @@ namespace utils
       auto unprocessToken = undoer([&processToken] { CloseHandle(processToken); });
       {
         LUID luid{};
-        if(!LookupPrivilegeValue(nullptr, L"SeProfileSingleProcessPrivilege", &luid))
+        if(!LookupPrivilegeValueW(nullptr, L"SeProfileSingleProcessPrivilege", &luid))
         {
           return win32_error();
         }
@@ -168,7 +168,7 @@ namespace utils
       auto unprocessToken = undoer([&processToken] { CloseHandle(processToken); });
       {
         LUID luid{};
-        if(!LookupPrivilegeValue(nullptr, L"SeIncreaseQuotaPrivilege", &luid))
+        if(!LookupPrivilegeValueW(nullptr, L"SeIncreaseQuotaPrivilege", &luid))
         {
           return win32_error();
         }


### PR DESCRIPTION
While this makes the headers UNICODE-agnostic, the exported CMake targets still add the preprocessor defines (but this is a quickcpplib issue).