### PR TITLE
Temporary File Discovery Fix

### DIFF
--- a/include/llfio/v2.0/detail/impl/posix/statfs.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/statfs.ipp
@@ -162,7 +162,12 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
           }
           scores[n].second = n;
         }
-        std::sort(scores.begin(), scores.end());
+        std::sort(scores.begin(), scores.end(), [](const auto& a, const auto& b) noexcept {
+          if (a.first == b.first) {
+            return a.second > b.second;
+          }
+          return a.first < b.first;
+        });
         auto temp(std::move(mountentries[scores.front().second]));
         mountentries.clear();
         mountentries.push_back(std::move(temp));


### PR DESCRIPTION
When attempting to discover temporary file locations each layer of
filesystem present at the candidate location is retrieved and evaluated
to see which is the most representative. Previously the tie breaker if
two (or more) candidates were equally representative was to choose the
lower layer. This was leading to "rootfs" being chosen on certain
systems which caused that candidate to be erroneously disregarded as a
storage-backed temporary file location.

Updated the tie breaker so that it breaks ties by always picking the
higher layer.