### PR TITLE
Fix linkage on Windows.

### DIFF
--- a/include/llfio/v2.0/detail/impl/map_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/map_handle.ipp
@@ -171,7 +171,7 @@ namespace detail
       return ret;
     }
   };
-  extern inline QUICKCPPLIB_SYMBOL_EXPORT map_handle_cache_t &map_handle_cache()
+  extern inline LLFIO_DECL map_handle_cache_t &map_handle_cache()
   {
     static map_handle_cache_t v;
     return v;


### PR DESCRIPTION
If a client executable is compiled against header-only variant of the library, it exports `map_handle_cache`.

While harmless, it's not quite correct, IMHO.