### PR TITLE
Remove external linkage declaration from friend declarations

### DIFF
--- a/include/llfio/v2.0/detail/impl/posix/test/io_uring_multiplexer.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/test/io_uring_multiplexer.ipp
@@ -97,7 +97,7 @@ namespace test
   */
   template <bool is_threadsafe> class linux_io_uring_multiplexer final : public byte_io_multiplexer_impl<is_threadsafe>
   {
-    friend LLFIO_HEADERS_ONLY_FUNC_SPEC result<byte_io_multiplexer_ptr> multiplexer_linux_io_uring(size_t threads, bool is_polling) noexcept;
+    friend result<byte_io_multiplexer_ptr> multiplexer_linux_io_uring(size_t threads, bool is_polling) noexcept;
 
     using _base = byte_io_multiplexer_impl<is_threadsafe>;
     using _multiplexer_lock_guard = typename _base::_lock_guard;

--- a/include/llfio/v2.0/directory_handle.hpp
+++ b/include/llfio/v2.0/directory_handle.hpp
@@ -324,7 +324,9 @@ public:
     LLFIO_LOG_FUNCTION_CALL(this);
     if(_.flags & flag::unlink_on_first_close)
     {
-      auto ret = unlink();
+      // if called from the destructor, no virtual dispatch will happen
+      // which is expected/fine in this case
+      auto ret = unlink();  // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
       if(!ret)
       {
         // File may have already been deleted, if so ignore

--- a/include/llfio/v2.0/fs_handle.hpp
+++ b/include/llfio/v2.0/fs_handle.hpp
@@ -154,7 +154,7 @@ inline result<filesystem::path> to_win32_path(const T &h, win32_path_namespace m
 class LLFIO_DECL fs_handle
 {
 #ifdef _WIN32
-  friend LLFIO_HEADERS_ONLY_FUNC_SPEC result<filesystem::path> to_win32_path(const fs_handle &h, win32_path_namespace mapping) noexcept;
+  friend result<filesystem::path> to_win32_path(const fs_handle &h, win32_path_namespace mapping) noexcept;
 #else
   friend inline result<filesystem::path> to_win32_path(const fs_handle &h, win32_path_namespace mapping) noexcept
   {


### PR DESCRIPTION
The `extern` keyword is not allowed to appear in friend declarations
which however only `clang` cares enough about to emit a diagnostic.
We completely omit the FUNC_SPEC here as all affected functions have
forward declarations.

Fixes #105 