### PR TITLE
build: Require at least CMake 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,7 @@
 #     (See accompanying file Licence.txt or copy at
 #           http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-
-cmake_policy(SET CMP0057 NEW)  # Enable IN_LIST operator
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 set(LLFIO_DEPENDENCY_QUICKCPPLIB_GIT_TAG "master" CACHE STRING "Which git tag to use for the QuickCppLib dependency")
 set(LLFIO_DEPENDENCY_OUTCOME_GIT_TAG "develop" CACHE STRING "Which git tag to use for the Outcome dependency")


### PR DESCRIPTION
The minimum supported CMake version is currently determined by what RHEL 7 ships.