### PR TITLE
Fix unaligned map_handle::zero_memory on windows and support COW

### DIFF
--- a/include/llfio/v2.0/detail/impl/posix/mapped_file_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/mapped_file_handle.ipp
@@ -59,6 +59,7 @@ result<mapped_file_handle::size_type> mapped_file_handle::_reserve(extent_type &
   }
   // Reserve the full reservation in address space
   section_handle::flag mapflags = section_handle::flag::nocommit | section_handle::flag::read;
+  mapflags |= _sh.section_flags() & section_handle::flag::cow;
   if(this->is_writable())
   {
     mapflags |= section_handle::flag::write;

--- a/include/llfio/v2.0/detail/impl/windows/map_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/map_handle.ipp
@@ -934,7 +934,7 @@ result<void> map_handle::zero_memory(buffer_type region) noexcept
   memset(region.data(), 0, region.size());
   if(region.size() >= utils::page_size())
   {
-    region = utils::round_to_page_size_larger(region, _pagesize);
+    region = utils::round_to_page_size_smaller(region, _pagesize);
     if(region.size() > 0)
     {
       OUTCOME_TRYV(win32_maps_apply(region.data(), region.size(), win32_map_sought::committed,

--- a/include/llfio/v2.0/detail/impl/windows/mapped_file_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/mapped_file_handle.ipp
@@ -63,6 +63,7 @@ result<mapped_file_handle::size_type> mapped_file_handle::_reserve(extent_type &
     return _reservation;
   }
   section_handle::flag mapflags = section_handle::flag::read;
+  mapflags |= _sh.section_flags() & section_handle::flag::cow;
   auto map_size = reservation;
   // Reserve the full reservation in address space
   if(this->is_writable())


### PR DESCRIPTION
If you try to zero an unaligned address in a map_handle, it zeros the whole surrounding page on windows.
Also pass the COW flag on to the map handle, otherwise the section is COW but the map is unwritable.