### PR TITLE
Fix build on android, and with LOGGING_LEVEL = 0

### DIFF
--- a/include/llfio/v2.0/config.hpp
+++ b/include/llfio/v2.0/config.hpp
@@ -55,6 +55,10 @@ Distributed under the Boost Software License, Version 1.0.
 #endif
 #endif
 
+#if LLFIO_LOGGING_LEVEL == 0
+#define LLFIO_DISABLE_PATHS_IN_FAILURE_INFO 1
+#endif
+
 #ifndef LLFIO_LOG_TO_OSTREAM
 #if !defined(NDEBUG) && !defined(LLFIO_DISABLE_LOG_TO_OSTREAM)
 #include <iostream>  // for std::cerr
@@ -239,8 +243,8 @@ LLFIO_V2_NAMESPACE_END
 #include "quickcpplib/config.hpp"
 #if LLFIO_LOGGING_LEVEL
 #include "quickcpplib/ringbuffer_log.hpp"
-#include "quickcpplib/utils/thread.hpp"
 #endif
+#include "quickcpplib/utils/thread.hpp"
 // Bring in filesystem
 #if defined(__has_include)
 // clang-format off

--- a/include/llfio/v2.0/detail/impl/path_discovery.ipp
+++ b/include/llfio/v2.0/detail/impl/path_discovery.ipp
@@ -31,6 +31,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <mutex>
 #include <new>
 #include <regex>
+#include <sstream>
 #include <vector>
 
 LLFIO_V2_NAMESPACE_EXPORT_BEGIN

--- a/include/llfio/v2.0/detail/impl/posix/process_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/process_handle.ipp
@@ -32,12 +32,12 @@ Distributed under the Boost Software License, Version 1.0.
 
 #ifdef __FreeBSD__
 #include <sys/sysctl.h>
-extern "C" char **environ;
 #endif
 #ifdef __APPLE__
 #include <mach-o/dyld.h>  // for _NSGetExecutablePath
-extern "C" char **environ;
 #endif
+
+extern "C" char **environ;
 
 LLFIO_V2_NAMESPACE_BEGIN
 
@@ -122,9 +122,6 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC std::unique_ptr<span<path_view_component>, proce
     // Laziness ...
     return {};
   }
-#ifdef __linux__
-  char **environ = __environ;
-#endif
   size_t bytesneeded = sizeof(span<path_view_component>);
   size_t count = 0;
   char **e;

--- a/include/llfio/v2.0/logging.hpp
+++ b/include/llfio/v2.0/logging.hpp
@@ -171,13 +171,24 @@ namespace detail
 
 LLFIO_V2_NAMESPACE_END
 
+#else  // LLFIO_LOGGING_LEVEL
+enum class log_level
+{
+  fatal
+};
+struct log_level_guard
+{
+  log_level_guard(log_level) {}
+};
+#define LLFIO_LOG_INST_TO_TLS(inst)
+#endif  // LLFIO_LOGGING_LEVEL
+
 #ifndef LLFIO_LOG_FATAL_TO_CERR
 #include <cstdio>
 #define LLFIO_LOG_FATAL_TO_CERR(expr)                                                                                                                          \
   fprintf(stderr, "%s\n", (expr));                                                                                                                             \
   fflush(stderr)
 #endif
-#endif  // LLFIO_LOGGING_LEVEL
 
 #if LLFIO_LOGGING_LEVEL >= 1
 #define LLFIO_LOG_FATAL(inst, message)                                                                                                                         \

--- a/include/llfio/v2.0/status_code.hpp
+++ b/include/llfio/v2.0/status_code.hpp
@@ -426,10 +426,9 @@ private:
   uint16_t _tls_path_id1{static_cast<uint16_t>(-1)}, _tls_path_id2{static_cast<uint16_t>(-1)};
   // The id of the relevant log entry in the LLFIO log (if logging enabled)
   size_t _log_id{static_cast<size_t>(-1)};
-
-public:
 #endif
 
+public:
   //! Default constructor
   error_info() = default;
   // Explicit construction from an error code


### PR DESCRIPTION
Fixes building with LLFIO_LOGGING_LEVEL = 0, and a couple of minor issues that arose when building for android.