### PR TITLE
Remove the need for C++ exceptions

### DIFF
--- a/include/llfio/revision.hpp
+++ b/include/llfio/revision.hpp
@@ -1,4 +1,4 @@
 // Note the second line of this file must ALWAYS be the git SHA, third line ALWAYS the git SHA update time
-#define LLFIO_PREVIOUS_COMMIT_REF    ccd234d05eb6611ffc686aabc781f93e0a1c3349
-#define LLFIO_PREVIOUS_COMMIT_DATE   "2024-12-21 16:36:10 +00:00"
-#define LLFIO_PREVIOUS_COMMIT_UNIQUE ccd234d0
+#define LLFIO_PREVIOUS_COMMIT_REF    39587fdce8abecbe931c9c24db53f8b7672633e8
+#define LLFIO_PREVIOUS_COMMIT_DATE   "2025-01-21 00:52:41 +00:00"
+#define LLFIO_PREVIOUS_COMMIT_UNIQUE 39587fdc

--- a/include/llfio/v2.0/algorithm/contents.hpp
+++ b/include/llfio/v2.0/algorithm/contents.hpp
@@ -89,7 +89,7 @@ namespace algorithm
 
     static std::shared_ptr<contents_type> _thread_contents(_state_type *state) noexcept
     {
-      try
+      LLFIO_TRY
       {
         static thread_local std::weak_ptr<contents_type> mycontents;
         auto ret = mycontents.lock();
@@ -103,7 +103,7 @@ namespace algorithm
         state->all_thread_contents.push_back(ret);
         return ret;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return {};
       }
@@ -116,7 +116,7 @@ namespace algorithm
     */
     virtual result<void> post_enumeration(void *data, const directory_handle &dirh, directory_handle::buffers_type &contents, size_t depth) noexcept
     {
-      try
+      LLFIO_TRY
       {
         auto *state = (_state_type *) data;
         (void) depth;
@@ -171,7 +171,7 @@ namespace algorithm
         }
         return success();
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }
@@ -183,7 +183,7 @@ namespace algorithm
     */
     virtual result<size_t> finished(void *data, result<size_t> result) noexcept
     {
-      try
+      LLFIO_TRY
       {
         auto *state = (_state_type *) data;
         state->contents.clear();
@@ -201,7 +201,7 @@ namespace algorithm
         state->all_thread_contents.clear();
         return result;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }

--- a/include/llfio/v2.0/algorithm/difference.hpp
+++ b/include/llfio/v2.0/algorithm/difference.hpp
@@ -69,7 +69,7 @@ namespace algorithm
     //! This override implements the summary
     virtual result<void> post_enumeration(void *data, const directory_handle &dirh, directory_handle::buffers_type &contents, size_t depth) noexcept override
     {
-      try
+      LLFIO_TRY
       {
         auto *state = (comparison_summary *) data;
         comparison_summary acc;
@@ -81,7 +81,7 @@ namespace algorithm
         state->operator+=(acc);
         return success();
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }

--- a/include/llfio/v2.0/algorithm/handle_adapter/cached_parent.hpp
+++ b/include/llfio/v2.0/algorithm/handle_adapter/cached_parent.hpp
@@ -151,14 +151,14 @@ namespace algorithm
       OUTCOME_TRYV(adapted_handle_type::relink(base, newpath, atomic_replace, d));
       _sph.reset();
       _leafname.clear();
-      try
+      LLFIO_TRY
       {
         auto r = detail::get_cached_path_handle(base, newpath);
         _sph = std::move(r.first);
         _leafname = std::move(r.second);
         return success();
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }
@@ -182,11 +182,11 @@ namespace algorithm
   {
     construct<T> constructor{std::forward<Args>(args)...};
     OUTCOME_TRY(auto &&h, constructor());
-    try
+    LLFIO_TRY
     {
       return cached_parent_handle_adapter<T>(std::move(h), constructor.base, constructor._path);
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -201,11 +201,11 @@ template <class T> struct construct<algorithm::cached_parent_handle_adapter<T>>
   result<algorithm::cached_parent_handle_adapter<T>> operator()() const noexcept
   {
     OUTCOME_TRY(auto &&h, args());
-    try
+    LLFIO_TRY
     {
       return algorithm::cached_parent_handle_adapter<T>(std::move(h), args.base, args._path);
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/algorithm/shared_fs_mutex/memory_map.hpp
+++ b/include/llfio/v2.0/algorithm/shared_fs_mutex/memory_map.hpp
@@ -195,7 +195,7 @@ namespace algorithm
       static result<memory_map> fs_mutex_map(const path_handle &base, path_view lockfile) noexcept
       {
         LLFIO_LOG_FUNCTION_CALL(0);
-        try
+        LLFIO_TRY
         {
           OUTCOME_TRY(auto &&ret, file_handle::file(base, lockfile, file_handle::mode::write, file_handle::creation::if_needed, file_handle::caching::reads));
           file_handle temph;
@@ -263,7 +263,7 @@ namespace algorithm
           lockinuse = std::move(lockinuse2);  // releases exclusive lock on all three offsets
           return memory_map(std::move(ret), std::move(temph), std::move(lockinuse.value()), std::move(hmap), std::move(temphmap));
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return error_from_exception();
         }

--- a/include/llfio/v2.0/algorithm/summarize.hpp
+++ b/include/llfio/v2.0/algorithm/summarize.hpp
@@ -236,7 +236,7 @@ namespace algorithm
     //! This override implements the summary
     virtual result<void> post_enumeration(void *data, const directory_handle &dirh, directory_handle::buffers_type &contents, size_t depth) noexcept override
     {
-      try
+      LLFIO_TRY
       {
         auto *state = (traversal_summary *) data;
         traversal_summary acc;
@@ -248,7 +248,7 @@ namespace algorithm
         state->operator+=(acc);
         return success();
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }

--- a/include/llfio/v2.0/algorithm/trivial_vector.hpp
+++ b/include/llfio/v2.0/algorithm/trivial_vector.hpp
@@ -248,7 +248,7 @@ namespace algorithm
       {
         if(i >= size())
         {
-          throw std::out_of_range("bounds exceeded");  // NOLINT
+          LLFIO_THROW std::out_of_range("bounds exceeded");  // NOLINT
         }
         return _begin[i];
       }
@@ -257,7 +257,7 @@ namespace algorithm
       {
         if(i >= size())
         {
-          throw std::out_of_range("bounds exceeded");  // NOLINT
+          LLFIO_THROW std::out_of_range("bounds exceeded");  // NOLINT
         }
         return _begin[i];
       }
@@ -314,7 +314,7 @@ namespace algorithm
       {
         if(n > max_size())
         {
-          throw std::length_error("Max size exceeded");  // NOLINT
+          LLFIO_THROW std::length_error("Max size exceeded");  // NOLINT
         }
         size_type current_size = size();
         size_type bytes = n * sizeof(value_type);
@@ -435,11 +435,11 @@ namespace algorithm
         // Trivially copyable, so memmove
         memmove(pos._v + 1, pos._v, (_end - pos._v) * sizeof(value_type));
         // BUT complex constructors may throw!
-        try
+        LLFIO_TRY
         {
           new(pos._v) value_type(std::forward<Args>(args)...);
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           memmove(pos._v, pos._v + 1, (_end - pos._v) * sizeof(value_type));
           throw;

--- a/include/llfio/v2.0/config.hpp
+++ b/include/llfio/v2.0/config.hpp
@@ -135,9 +135,6 @@ Distributed under the Boost Software License, Version 1.0.
 #include "quickcpplib/cpp_feature.h"
 
 #ifndef STANDARDESE_IS_IN_THE_HOUSE
-#ifndef __cpp_exceptions
-#error LLFIO needs C++ exceptions to be turned on
-#endif
 #ifndef __cpp_alias_templates
 #error LLFIO needs template alias support in the compiler
 #endif
@@ -165,6 +162,20 @@ Distributed under the Boost Software License, Version 1.0.
 // clang-format on
 #error LLFIO needs an implementation of the Filesystem TS in the standard library
 #endif
+#endif
+#ifndef __cpp_exceptions
+#define LLFIO_TRY      if (true)
+#define LLFIO_CATCH(x) if (false)
+#define LLFIO_CATCH_SPECIFIC_BEGIN(x) (void)([&](x) {
+#define LLFIO_CATCH_SPECIFIC_END      });
+#define LLFIO_THROW
+#else
+// Else proceed normally.
+#define LLFIO_TRY      try
+#define LLFIO_CATCH(e) catch(e)
+#define LLFIO_CATCH_SPECIFIC_BEGIN(e) LLFIO_CATCH(e) {
+#define LLFIO_CATCH_SPECIFIC_END      }
+#define LLFIO_THROW throw
 #endif
 #endif
 

--- a/include/llfio/v2.0/deadline.h
+++ b/include/llfio/v2.0/deadline.h
@@ -96,7 +96,7 @@ struct LLFIO_DEADLINE_NAME
   {
     if(steady)
     {
-      throw std::invalid_argument("Not a UTC deadline!");  // NOLINT
+      LLFIO_THROW std::invalid_argument("Not a UTC deadline!");  // NOLINT
     }
     std::chrono::system_clock::time_point tp(std::chrono::system_clock::from_time_t(utc.tv_sec));
     tp += std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::nanoseconds(utc.tv_nsec));

--- a/include/llfio/v2.0/detail/impl/cached_parent_handle_adapter.ipp
+++ b/include/llfio/v2.0/detail/impl/cached_parent_handle_adapter.ipp
@@ -46,7 +46,7 @@ namespace algorithm
     }
     LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<filesystem::path> cached_path_handle::current_path(const filesystem::path &append) noexcept
     {
-      try
+      LLFIO_TRY
       {
         auto ret = h.current_path();
         auto &map = cached_path_handle_map();
@@ -65,7 +65,7 @@ namespace algorithm
         }
         return _lastpath / append;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }

--- a/include/llfio/v2.0/detail/impl/clone.ipp
+++ b/include/llfio/v2.0/detail/impl/clone.ipp
@@ -32,7 +32,7 @@ namespace algorithm
                                                                               bool preserve_timestamps, bool force_copy_now, file_handle::creation creation,
                                                                               deadline d) noexcept
   {
-    try
+    LLFIO_TRY
     {
       LLFIO_LOG_FUNCTION_CALL(&src);
       filesystem::path destleaf_;
@@ -104,7 +104,7 @@ namespace algorithm
       failed = false;
       return copied.length;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -113,7 +113,7 @@ namespace algorithm
   LLFIO_HEADERS_ONLY_FUNC_SPEC result<bool> relink_or_clone_copy_unlink(file_handle &src, const path_handle &destdir, path_view destleaf, bool atomic_replace,
                                                                         bool preserve_timestamps, bool force_copy_now, deadline d) noexcept
   {
-    try
+    LLFIO_TRY
     {
       LLFIO_LOG_FUNCTION_CALL(&src);
       filesystem::path destleaf_;
@@ -229,7 +229,7 @@ namespace algorithm
       OUTCOME_TRY(src._replace_handle(std::move(desth)));
       return true;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/dynamic_thread_pool_group.ipp
+++ b/include/llfio/v2.0/detail/impl/dynamic_thread_pool_group.ipp
@@ -741,13 +741,13 @@ namespace detail
     void _add_thread(threadpool_guard & /*unused*/)
     {
       thread_t *p = nullptr;
-      try
+      LLFIO_TRY
       {
         p = new thread_t;
         _append_to_list(threadpool_active, p);
         p->thread = std::thread([this, p] { _execute_work(p); });
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         if(p != nullptr)
         {
@@ -1286,7 +1286,7 @@ public:
   result<void> init()
   {
     LLFIO_LOG_FUNCTION_CALL(this);
-    try
+    LLFIO_TRY
     {
       auto &impl = detail::global_dynamic_thread_pool();
       _nesting_level = detail::global_dynamic_thread_pool_thread_local_state().nesting_level;
@@ -1311,7 +1311,7 @@ public:
       impl.workqueue->items.insert(this);
       return success();
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -1448,13 +1448,13 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC uint32_t dynamic_thread_pool_group::ms_sleep_for
 
 LLFIO_HEADERS_ONLY_FUNC_SPEC result<dynamic_thread_pool_group_ptr> make_dynamic_thread_pool_group() noexcept
 {
-  try
+  LLFIO_TRY
   {
     auto ret = std::make_unique<dynamic_thread_pool_group_impl>();
     OUTCOME_TRY(ret->init());
     return dynamic_thread_pool_group_ptr(std::move(ret));
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -1620,11 +1620,11 @@ namespace detail
         std::cout << "*** DTP " << self << " wakes, state = " << self->state << std::endl;
 #endif
         g.unlock();
-        try
+        LLFIO_TRY
         {
           populate_threadmetrics(now_steady);
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
         }
         continue;
@@ -1643,7 +1643,7 @@ namespace detail
         _workerthread(workitem, nullptr);
       }
       // workitem->_internalworkh should be null, however workitem may also no longer exist
-      try
+      LLFIO_TRY
       {
         if(populate_threadmetrics(now_steady))
         {
@@ -1658,7 +1658,7 @@ namespace detail
           return;
         }
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
       }
     }
@@ -1862,7 +1862,7 @@ namespace detail
   inline result<void> global_dynamic_thread_pool_impl::submit(dynamic_thread_pool_group_impl_guard &g, dynamic_thread_pool_group_impl *group,
                                                               span<dynamic_thread_pool_group::work_item *> work) noexcept
   {
-    try
+    LLFIO_TRY
     {
       if(work.empty())
       {
@@ -1931,7 +1931,7 @@ namespace detail
       g.lock();
       return success();
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -2394,7 +2394,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC dynamic_thread_pool_group::io_aware_work_item::i
       {
         if(!h.h->is_seekable())
         {
-          throw std::runtime_error("Supplied handle is not seekable");
+          LLFIO_THROW std::runtime_error("Supplied handle is not seekable");
         }
         auto *fh = static_cast<file_handle *>(h.h);
         auto unique_id = fh->unique_id();
@@ -2410,7 +2410,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC dynamic_thread_pool_group::io_aware_work_item::i
             {
               r.value();
             }
-            throw std::runtime_error("statfs::f_iosinprogress unavailable for supplied handle");
+            LLFIO_THROW std::runtime_error("statfs::f_iosinprogress unavailable for supplied handle");
           }
           it->second.last_updated = std::chrono::steady_clock::now();
         }

--- a/include/llfio/v2.0/detail/impl/map_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/map_handle.ipp
@@ -272,7 +272,7 @@ result<map_handle> map_handle::_recycled_map(size_type bytes, section_handle::fl
 
 bool map_handle::_recycle_map() noexcept
 {
-  try
+  LLFIO_TRY
   {
     LLFIO_LOG_FUNCTION_CALL(this);
     auto *c = detail::map_handle_cache();
@@ -311,7 +311,7 @@ bool map_handle::_recycle_map() noexcept
 #endif
     return c->add(_reservation, _pagesize, _addr);
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return false;
   }

--- a/include/llfio/v2.0/detail/impl/path_discovery.ipp
+++ b/include/llfio/v2.0/detail/impl/path_discovery.ipp
@@ -92,7 +92,7 @@ namespace path_discovery
     {
       return ps.all;
     }
-    try
+    LLFIO_TRY
     {
       std::vector<std::pair<discovered_path::source_type, detail::_store::_discovered_path>> raw = _all_temporary_directories(overrides, fallbacks);
       if(raw.empty())
@@ -123,13 +123,12 @@ namespace path_discovery
         ps.all.push_back(std::move(dp));
       }
     }
-    catch(const std::exception &e)
-    {
+    LLFIO_CATCH_SPECIFIC_BEGIN(const std::exception &e)
       std::string msg("path_discovery::all_temporary_directories() saw exception thrown: ");
       msg.append(e.what());
       LLFIO_LOG_WARN(nullptr, msg.c_str());
-    }
-    catch(...)
+    LLFIO_CATCH_SPECIFIC_END
+    LLFIO_CATCH(...)
     {
       LLFIO_LOG_WARN(nullptr, "path_discovery::all_temporary_directories() saw unknown exception throw");
     }
@@ -150,7 +149,7 @@ namespace path_discovery
     {
       return ps.verified;
     }
-    try
+    LLFIO_TRY
     {
       // Firstly go try to open and stat all items
       for(size_t n = 0; n < ps.all.size(); n++)
@@ -261,14 +260,13 @@ namespace path_discovery
         (void) ps._all[n].h.close();
       }
     }
-    catch(const std::exception &e)
-    {
+    LLFIO_CATCH_SPECIFIC_BEGIN(const std::exception &e)
       std::string msg("path_discovery::verified_temporary_directories() saw exception thrown: ");
       msg.append(e.what());
       LLFIO_LOG_FATAL(nullptr, msg.c_str());
       abort();
-    }
-    catch(...)
+    LLFIO_CATCH_SPECIFIC_END
+    LLFIO_CATCH(...)
     {
       LLFIO_LOG_FATAL(nullptr, "path_discovery::verified_temporary_directories() saw unknown exception throw");
       abort();

--- a/include/llfio/v2.0/detail/impl/path_view.ipp
+++ b/include/llfio/v2.0/detail/impl/path_view.ipp
@@ -106,7 +106,7 @@ namespace detail
         // If input is supposed to be valid UTF, barf
         if(std::is_same<SrcT, char8_t>::value || std::is_same<SrcT, char16_t>::value)
         {
-          throw std::system_error(make_error_code(std::errc::illegal_byte_sequence));
+          LLFIO_THROW std::system_error(make_error_code(std::errc::illegal_byte_sequence));
         }
         // Otherwise proceed anyway :)
         LLFIO_LOG_WARN(nullptr, "path_view_component::rendered_path saw failure to completely convert input encoding");
@@ -222,7 +222,7 @@ namespace detail
       state.buffer.Buffer = (wchar_t *) malloc(state.buffer.MaximumLength);
       if(nullptr == state.buffer.Buffer)
       {
-        throw std::bad_alloc();
+        LLFIO_THROW std::bad_alloc();
       }
       // Do the conversion UTF-8 to UTF-16
       ntstat = RtlUTF8ToUnicodeN(state.buffer.Buffer, state.buffer.Length, &written, (const char *) src_buffer, static_cast<ULONG>(src_buffer_length));
@@ -242,7 +242,7 @@ namespace detail
       state.buffer.Buffer = (wchar_t *) malloc(state.buffer.MaximumLength);
       if(nullptr == state.buffer.Buffer)
       {
-        throw std::bad_alloc();
+        LLFIO_THROW std::bad_alloc();
       }
       // Do the conversion UTF-8 to UTF-16
       auto *src_ptr = src_buffer;
@@ -258,12 +258,12 @@ namespace detail
       if(std::codecvt_base::error == result)
       {
         // If input is supposed to be valid UTF, barf
-        throw std::system_error(make_error_code(std::errc::illegal_byte_sequence));
+        LLFIO_THROW std::system_error(make_error_code(std::errc::illegal_byte_sequence));
       }
       written = (DWORD)((dest_ptr - state.buffer.Buffer) * sizeof(wchar_t));
       if(written > 65535)
       {
-        throw std::system_error(make_error_code(std::errc::no_buffer_space));
+        LLFIO_THROW std::system_error(make_error_code(std::errc::no_buffer_space));
       }
       state.buffer.Length = (USHORT) written;
     }

--- a/include/llfio/v2.0/detail/impl/posix/byte_socket_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/byte_socket_handle.ipp
@@ -380,7 +380,7 @@ namespace ip
   result<resolver_ptr> resolve(string_view name, string_view service, family _family, deadline d, resolve_flag flags) noexcept
   {
     LLFIO_LOG_FUNCTION_CALL(nullptr);
-    try
+    LLFIO_TRY
     {
       detail::resolver_impl *p;
       resolver_ptr ret((p = new detail::resolver_impl(name, service)));
@@ -470,7 +470,7 @@ namespace ip
 #endif
       return {std::move(ret)};
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/posix/file_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/file_handle.ipp
@@ -162,11 +162,11 @@ result<file_handle> file_handle::temp_inode(const path_handle &dirh, mode _mode,
   std::string random;
   for(;;)
   {
-    try
+    LLFIO_TRY
     {
       random = utils::random_string(32) + ".tmp";
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -369,7 +369,7 @@ result<file_handle::extent_type> file_handle::truncate(file_handle::extent_type 
 result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexcept
 {
   LLFIO_LOG_FUNCTION_CALL(this);
-  try
+  LLFIO_TRY
   {
     std::vector<file_handle::extent_pair> out;
     out.reserve(64);
@@ -445,7 +445,7 @@ result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexc
 #endif
     return out;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -454,7 +454,7 @@ result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexc
 result<file_handle::extent_pair> file_handle::clone_extents_to(file_handle::extent_pair extent, byte_io_handle &dest_, byte_io_handle::extent_type destoffset,
                                                                deadline d, bool force_copy_now, bool emulate_if_unsupported) noexcept
 {
-  try
+  LLFIO_TRY
   {
     LLFIO_LOG_FUNCTION_CALL(this);
 
@@ -977,7 +977,7 @@ result<file_handle::extent_pair> file_handle::clone_extents_to(file_handle::exte
     }
     return ret;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -1010,7 +1010,7 @@ result<file_handle::extent_type> file_handle::zero(file_handle::extent_pair exte
     OUTCOME_TRY(auto &&written, write(extent.offset, {{buffer, (size_type) extent.length}}, d));
     return written;
   }
-  try
+  LLFIO_TRY
   {
     extent_type ret = 0;
     auto blocksize = utils::file_buffer_default_size();
@@ -1027,7 +1027,7 @@ result<file_handle::extent_type> file_handle::zero(file_handle::extent_pair exte
     }
     return ret;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/fs_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/fs_handle.ipp
@@ -71,7 +71,7 @@ namespace detail
         end_utc = d.to_time_point();
       }
     }
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -179,7 +179,7 @@ namespace detail
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/posix/handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/handle.ipp
@@ -55,7 +55,7 @@ handle::~handle()
 result<handle::path_type> handle::current_path() const noexcept
 {
   LLFIO_LOG_FUNCTION_CALL(this);
-  try
+  LLFIO_TRY
   {
     // Most efficient, least memory copying method is direct fill of a string which is moved into filesystem::path
     filesystem::path::string_type ret;
@@ -130,7 +130,7 @@ result<handle::path_type> handle::current_path() const noexcept
 #endif
     return path_type(std::move(ret));
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/path_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/path_handle.ipp
@@ -29,7 +29,7 @@ Distributed under the Boost Software License, Version 1.0.
 LLFIO_V2_NAMESPACE_BEGIN
 
 result<bool> path_handle::exists(path_view_type path) const noexcept {
-  try
+  LLFIO_TRY
   {
     LLFIO_LOG_FUNCTION_CALL(this);
     path_view::zero_terminated_rendered_path<> zpath(path);
@@ -45,7 +45,7 @@ result<bool> path_handle::exists(path_view_type path) const noexcept {
     }
     return (x == F_OK);
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/pipe_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/pipe_handle.ipp
@@ -43,7 +43,7 @@ result<pipe_handle> pipe_handle::pipe(pipe_handle::path_view_type path, pipe_han
   path_handle dirh;
   path_type leafname;
   int dirhfd = AT_FDCWD;
-  try
+  LLFIO_TRY
   {
     // Take a path handle to the directory containing the symlink
     auto path_parent = path.parent_path();
@@ -59,7 +59,7 @@ result<pipe_handle> pipe_handle::pipe(pipe_handle::path_view_type path, pipe_han
       dirhfd = dirh.native_handle().fd;
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/process_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/process_handle.ipp
@@ -218,7 +218,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC const process_handle &process_handle::current() 
 LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<process_handle> process_handle::launch_process(path_view path, span<path_view_component> args,
                                                                                       span<path_view_component> env, flag flags) noexcept
 {
-  try
+  LLFIO_TRY
   {
     result<process_handle> ret(in_place_type<process_handle>, native_handle_type(), flags);
     native_handle_type &nativeh = ret.value()._v;
@@ -366,7 +366,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<process_handle> process_handle::launch_pr
 #endif
     return ret;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/statfs.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/statfs.ipp
@@ -103,7 +103,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
     }
     if(!!(wanted & want::flags) || !!(wanted & want::fstypename) || !!(wanted & want::mntfromname) || !!(wanted & want::mntonname))
     {
-      try
+      LLFIO_TRY
       {
         struct mountentry
         {
@@ -224,7 +224,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
           ++ret;
         }
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }
@@ -347,7 +347,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<size_t> statfs_t::fill(const handle &h, s
 LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fill_ios(const handle &h, const std::string & /*unused*/) noexcept
 {
   (void) h;
-  try
+  LLFIO_TRY
   {
 #ifdef __linux__
     struct stat s
@@ -394,7 +394,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fi
         }
       }
     }
-    try
+    LLFIO_TRY
     {
       int fd = ::open("/proc/diskstats", O_RDONLY);
       if(fd >= 0)
@@ -414,11 +414,11 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fi
             diskstats.resize(read);
             break;
           }
-          try
+          LLFIO_TRY
           {
             diskstats.resize(diskstats.size() << 1);
           }
-          catch(...)
+          LLFIO_CATCH(...)
           {
             ::close(fd);
             throw;
@@ -478,7 +478,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fi
         // return all bits one to indicate soft failure.
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -492,7 +492,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fi
 #endif
     return {-1, detail::constexpr_float_allbits_set_nan()};
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/storage_profile.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/storage_profile.ipp
@@ -52,7 +52,7 @@ namespace storage_profile
       }
       else
       {
-        try
+        LLFIO_TRY
         {
           struct utsname name
           {
@@ -65,7 +65,7 @@ namespace storage_profile
           sp.os_name.value = os_name = name.sysname;
           sp.os_ver.value = os_ver = name.release;
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }
@@ -86,7 +86,7 @@ namespace storage_profile
       }
       else
       {
-        try
+        LLFIO_TRY
         {
           struct utsname name
           {
@@ -199,7 +199,7 @@ namespace storage_profile
           cpu_architecture = sp.cpu_architecture.value;
           cpu_physical_cores = sp.cpu_physical_cores.value;
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }
@@ -241,7 +241,7 @@ namespace storage_profile
       outcome<void> _device(storage_profile &sp, file_handle & /*unused*/, const std::string &_mntfromname, const std::string &fstypename) noexcept
       {
         (void) fstypename;
-        try
+        LLFIO_TRY
         {
           std::string mntfromname(_mntfromname);
           // Firstly open a handle to the device
@@ -312,7 +312,7 @@ namespace storage_profile
           ioctl(deviceh.native_handle().fd, DKIOCGETBLOCKCOUNT, &sp.device_size.value);
 #endif
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }

--- a/include/llfio/v2.0/detail/impl/posix/symlink_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/symlink_handle.ipp
@@ -64,7 +64,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<void> symlink_handle::_create_symlink(con
     }
   }
   path_view::zero_terminated_rendered_path<> zpath(target);
-  try
+  LLFIO_TRY
   {
     if(atomic_replace)
     {
@@ -124,7 +124,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<void> symlink_handle::_create_symlink(con
       return success();
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -138,11 +138,11 @@ result<symlink_handle> symlink_handle::reopen(mode mode_, deadline d) const noex
   ret.value()._v.behaviour = _v.behaviour;
   OUTCOME_TRY(auto &&dirh, _dirh.clone());
   ret.value()._dirh = path_handle(std::move(dirh));
-  try
+  LLFIO_TRY
   {
     ret.value()._leafname = _leafname;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -219,7 +219,7 @@ result<symlink_handle> symlink_handle::reopen(mode mode_, deadline d) const noex
 result<symlink_handle::path_type> symlink_handle::current_path() const noexcept
 {
   LLFIO_LOG_FUNCTION_CALL(this);
-  try
+  LLFIO_TRY
   {
     // Deleted?
     if(!_dirh.is_valid() && _leafname.empty())
@@ -243,7 +243,7 @@ result<symlink_handle::path_type> symlink_handle::current_path() const noexcept
       return {std::move(dirpath)};
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -253,7 +253,7 @@ result<void> symlink_handle::relink(const path_handle &base, path_view_type path
 {
   LLFIO_LOG_FUNCTION_CALL(this);
   OUTCOME_TRY(fs_handle::relink(base, path, atomic_replace, d));
-  try
+  LLFIO_TRY
   {
     // Take a path handle to the directory containing the symlink
     auto path_parent = path.parent_path();
@@ -269,7 +269,7 @@ result<void> symlink_handle::relink(const path_handle &base, path_view_type path
       _dirh = std::move(dh);
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -312,7 +312,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<symlink_handle> symlink_handle::symlink(c
   path_type &leafname = ret.value()._leafname;
 #endif
   int dirhfd = AT_FDCWD;
-  try
+  LLFIO_TRY
   {
     // Take a path handle to the directory containing the symlink
     auto path_parent = path.parent_path();
@@ -338,7 +338,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<symlink_handle> symlink_handle::symlink(c
       dirhfd = dirh->native_handle().fd;
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/posix/test/io_uring_multiplexer.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/test/io_uring_multiplexer.ipp
@@ -1225,7 +1225,7 @@ namespace test
 
   LLFIO_HEADERS_ONLY_FUNC_SPEC result<byte_io_multiplexer_ptr> multiplexer_linux_io_uring(size_t threads, bool is_polling) noexcept
   {
-    try
+    LLFIO_TRY
     {
       if(1 == threads)
       {
@@ -1238,7 +1238,7 @@ namespace test
       OUTCOME_TRY(ret->init(false, ret->_nonseekable));
       return byte_io_multiplexer_ptr(ret.release());
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/posix/utils.ipp
+++ b/include/llfio/v2.0/detail/impl/posix/utils.ipp
@@ -224,7 +224,7 @@ namespace utils
   result<process_memory_usage> current_process_memory_usage(process_memory_usage::want want) noexcept
   {
 #ifdef __linux__
-    try
+    LLFIO_TRY
     {
       auto fill_buffer = [](std::vector<char> &buffer, const char *path) -> result<void>
       {
@@ -535,7 +535,7 @@ namespace utils
       }
       return ret;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -650,7 +650,7 @@ namespace utils
   {
     process_cpu_usage ret;
 #ifdef __linux__
-    try
+    LLFIO_TRY
     {
       /* Need to multiply all below by 1000000000ULL / sysconf(_SC_CLK_TCK)
 
@@ -721,7 +721,7 @@ namespace utils
       ret.system_ns_in_idle_mode *= ts_multiplier;
       return ret;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/safe_byte_ranges.ipp
+++ b/include/llfio/v2.0/detail/impl/safe_byte_ranges.ipp
@@ -377,7 +377,7 @@ namespace algorithm
       }
       LLFIO_HEADERS_ONLY_FUNC_SPEC result<std::shared_ptr<shared_fs_mutex>> inode_to_fs_mutex(const path_handle &base, path_view lockfile) noexcept
       {
-        try
+        LLFIO_TRY
         {
           path_view::zero_terminated_rendered_path<> zpath(lockfile);
           struct stat s
@@ -413,7 +413,7 @@ namespace algorithm
           }
           return ret;
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return error_from_exception();
         }

--- a/include/llfio/v2.0/detail/impl/storage_profile.ipp
+++ b/include/llfio/v2.0/detail/impl/storage_profile.ipp
@@ -170,7 +170,7 @@ namespace storage_profile
       }
       else
       {
-        try
+        LLFIO_TRY
         {
           size_t chunksize = 256 * 1024 * 1024;
 #ifdef WIN32
@@ -211,7 +211,7 @@ namespace storage_profile
           }
           sp.mem_min_bandwidth.value = static_cast<unsigned long long>(static_cast<double>(count) * chunksize / 10);
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }
@@ -346,7 +346,7 @@ namespace storage_profile
     // Device name, size, min i/o size
     outcome<void> device(storage_profile &sp, file_handle &h) noexcept
     {
-      try
+      LLFIO_TRY
       {
         statfs_t fsinfo;
         OUTCOME_TRYV(fsinfo.fill(h, statfs_t::want::iosize | statfs_t::want::mntfromname | statfs_t::want::fstypename));
@@ -357,7 +357,7 @@ namespace storage_profile
         OUTCOME_TRYV(posix::_device(sp, h, fsinfo.f_mntfromname, fsinfo.f_fstypename));
 #endif
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }
@@ -366,7 +366,7 @@ namespace storage_profile
     // FS name, config, size, in use
     outcome<void> fs(storage_profile &sp, file_handle &h) noexcept
     {
-      try
+      LLFIO_TRY
       {
         statfs_t fsinfo;
         OUTCOME_TRYV(fsinfo.fill(h));
@@ -375,7 +375,7 @@ namespace storage_profile
         sp.fs_size.value = fsinfo.f_blocks * fsinfo.f_bsize;
         sp.fs_in_use.value = static_cast<float>(fsinfo.f_blocks - fsinfo.f_bfree) / fsinfo.f_blocks;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }
@@ -395,7 +395,7 @@ namespace storage_profile
       {
         return success();
       }
-      try
+      LLFIO_TRY
       {
         using off_t = byte_io_handle::extent_type;
         sp.max_aligned_atomic_rewrite.value = 1;
@@ -420,7 +420,7 @@ namespace storage_profile
               auto _h(srch.reopen());
               if(!_h)
               {
-                throw std::runtime_error(std::string("concurrency::atomic_rewrite_quantum: "  // NOLINT
+                LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_quantum: "  // NOLINT
                                                      "Could not open work file due to ") +
                                          _h.error().message().c_str());
               }
@@ -459,7 +459,7 @@ namespace storage_profile
               auto _h(srch.reopen());
               if(!_h)
               {
-                throw std::runtime_error(std::string("concurrency::atomic_rewrite_quantum: "  // NOLINT
+                LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_quantum: "  // NOLINT
                                                      "Could not open work file due to ") +
                                          _h.error().message().c_str());
               }
@@ -564,7 +564,7 @@ namespace storage_profile
                 auto _h(srch.reopen());
                 if(!_h)
                 {
-                  throw std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
+                  LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
                                                        "quantum: Could not open work file "
                                                        "due to ") +
                                            _h.error().message().c_str());
@@ -604,7 +604,7 @@ namespace storage_profile
                 auto _h(srch.reopen());
                 if(!_h)
                 {
-                  throw std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
+                  LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
                                                        "quantum: Could not open work file "
                                                        "due to ") +
                                            _h.error().message().c_str());
@@ -676,7 +676,7 @@ namespace storage_profile
           }
         }
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }
@@ -695,7 +695,7 @@ namespace storage_profile
         return success();
       }
 #endif
-      try
+      LLFIO_TRY
       {
         using off_t = byte_io_handle::extent_type;
         auto size = static_cast<size_t>(sp.max_aligned_atomic_rewrite.value);
@@ -725,7 +725,7 @@ namespace storage_profile
                   auto _h(srch.reopen());
                   if(!_h)
                   {
-                    throw std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
+                    LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
                                                          "offset_boundary: Could not open "
                                                          "work file due to ") +
                                              _h.error().message().c_str());
@@ -765,7 +765,7 @@ namespace storage_profile
                   auto _h(srch.reopen());
                   if(!_h)
                   {
-                    throw std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
+                    LLFIO_THROW std::runtime_error(std::string("concurrency::atomic_rewrite_"  // NOLINT
                                                          "offset_boundary: Could not open "
                                                          "work file due to ") +
                                              _h.error().message().c_str());
@@ -838,7 +838,7 @@ namespace storage_profile
           }
         }
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }
@@ -859,7 +859,7 @@ namespace storage_profile
       static constexpr size_t memory_to_use = 128 * 1024 * 1024;  // 1Gb
       // static const unsigned clock_overhead = system::_clock_granularity_and_overhead().overhead;
       static const unsigned clock_granularity = system::_clock_granularity_and_overhead().granularity;
-      try
+      LLFIO_TRY
       {
         std::vector<file_handle> _workfiles;
         _workfiles.reserve(noreaders + nowriters);
@@ -1046,7 +1046,7 @@ namespace storage_profile
         s._99999 = totalresults[static_cast<size_t>(0.99999 * totalresults.size())];
         return s;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }
@@ -1184,7 +1184,7 @@ namespace storage_profile
 #ifdef LLFIO_STORAGE_PROFILE_PIN_THREADS
       SetThreadAffinityMask(GetCurrentThread(), 1ULL << (no * 2));
 #endif
-      try
+      LLFIO_TRY
       {
         directory_handle dirh(directory_handle::directory(srch.parent_path_handle().value(), "testdir", directory_handle::mode::write, directory_handle::creation::if_needed).value());
         auto flags = srch.flags();
@@ -1295,7 +1295,7 @@ namespace storage_profile
         dirh.unlink().value();
         return s;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return std::current_exception();
       }

--- a/include/llfio/v2.0/detail/impl/test/null_multiplexer.ipp
+++ b/include/llfio/v2.0/detail/impl/test/null_multiplexer.ipp
@@ -584,7 +584,7 @@ namespace test
 
   LLFIO_HEADERS_ONLY_FUNC_SPEC result<byte_io_multiplexer_ptr> multiplexer_null(size_t threads, bool disable_immediate_completions) noexcept
   {
-    try
+    LLFIO_TRY
     {
       if(1 == threads)
       {
@@ -596,7 +596,7 @@ namespace test
       OUTCOME_TRY(ret->init(threads, disable_immediate_completions));
       return byte_io_multiplexer_ptr(ret.release());
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/tls_socket_sources/openssl.ipp
+++ b/include/llfio/v2.0/detail/impl/tls_socket_sources/openssl.ipp
@@ -247,7 +247,7 @@ namespace detail
     SYSTEM_ERROR2_NORETURN virtual void _do_throw_exception(const OUTCOME_V2_NAMESPACE::experimental::status_code<void> &code) const override
     {
       auto &c = static_cast<const OUTCOME_V2_NAMESPACE::experimental::status_code<openssl_error_domain> &>(code);
-      throw OUTCOME_V2_NAMESPACE::experimental::status_error<openssl_error_domain>(c);
+      LLFIO_THROW OUTCOME_V2_NAMESPACE::experimental::status_error<openssl_error_domain>(c);
     }
   };
   constexpr openssl_error_domain openssl_error_domain_inst;
@@ -305,7 +305,7 @@ namespace detail
     SYSTEM_ERROR2_NORETURN virtual void _do_throw_exception(const OUTCOME_V2_NAMESPACE::experimental::status_code<void> &code) const override
     {
       auto &c = static_cast<const OUTCOME_V2_NAMESPACE::experimental::status_code<x509_error_domain> &>(code);
-      throw OUTCOME_V2_NAMESPACE::experimental::status_error<x509_error_domain>(c);
+      LLFIO_THROW OUTCOME_V2_NAMESPACE::experimental::status_error<x509_error_domain>(c);
     }
   };
   constexpr x509_error_domain x509_error_domain_inst;
@@ -1224,13 +1224,13 @@ public:
 
   virtual result<void> set_authentication_certificates_path(path_view identifier) noexcept override
   {
-    try
+    LLFIO_TRY
     {
       LLFIO_LOG_FUNCTION_CALL(this);
       _authentication_certificates_path = identifier.path();
       return success();
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -1238,7 +1238,7 @@ public:
 
   virtual result<string_view> set_connect_hostname(string_view host, uint16_t port) noexcept override
   {
-    try
+    LLFIO_TRY
     {
       LLFIO_LOG_FUNCTION_CALL(this);
       _connect_hostname_port.assign(host.data(), host.size());
@@ -1267,7 +1267,7 @@ public:
       }
       return string_view(_connect_hostname_port).substr(host.size() + 1);
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -1618,13 +1618,13 @@ public:
 
   virtual result<void> set_authentication_certificates_path(path_view identifier) noexcept override
   {
-    try
+    LLFIO_TRY
     {
       LLFIO_LOG_FUNCTION_CALL(this);
       _authentication_certificates_path = identifier.path();
       return success();
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/traverse.ipp
+++ b/include/llfio/v2.0/detail/impl/traverse.ipp
@@ -52,7 +52,7 @@ namespace algorithm
     data,
     [&]() -> result<size_t>
     {
-      try
+      LLFIO_TRY
       {
         LLFIO_LOG_FUNCTION_CALL(&_topdirh);
         std::shared_ptr<directory_handle> topdirh;
@@ -574,7 +574,7 @@ namespace algorithm
 #endif
         return state.dirs_processed;
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }

--- a/include/llfio/v2.0/detail/impl/windows/byte_socket_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/byte_socket_handle.ipp
@@ -199,11 +199,11 @@ namespace ip
       p->clear();
       auto &cache = resolver_impl_cache();
       std::lock_guard<std::mutex> g(cache.lock);
-      try
+      LLFIO_TRY
       {
         cache.list.push_back(p);
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         delete p;
       }
@@ -270,7 +270,7 @@ namespace ip
   result<resolver_ptr> resolve(string_view name, string_view service, family _family, deadline d, resolve_flag flags) noexcept
   {
     LLFIO_LOG_FUNCTION_CALL(nullptr);
-    try
+    LLFIO_TRY
     {
       windows_nt_kernel::init();
       using namespace windows_nt_kernel;
@@ -380,7 +380,7 @@ namespace ip
       p->check(0);
       return {std::move(ret)};
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/detail/impl/windows/file_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/file_handle.ipp
@@ -1,5 +1,5 @@
 /* A handle to a file
-(C) 2015-2024 Niall Douglas <http://www.nedproductions.biz/> (16 commits)
+(C) 2015-2021 Niall Douglas <http://www.nedproductions.biz/> (16 commits)
 File Created: Dec 2015
 
 
@@ -219,7 +219,7 @@ result<file_handle> file_handle::temp_inode(const path_handle &dirh, mode _mode,
   std::wstring random(68, 0);
   for(;;)
   {
-    try
+    LLFIO_TRY
     {
       _random = utils::random_string(32) + ".tmp";
       for(size_t n = 0; n < _random.size(); n++)
@@ -227,7 +227,7 @@ result<file_handle> file_handle::temp_inode(const path_handle &dirh, mode _mode,
         random[n] = _random[n];
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -367,7 +367,7 @@ result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexc
   windows_nt_kernel::init();
   using namespace windows_nt_kernel;
   LLFIO_LOG_FUNCTION_CALL(this);
-  try
+  LLFIO_TRY
   {
     static_assert(sizeof(file_handle::extent_pair) == sizeof(FILE_ALLOCATED_RANGE_BUFFER),
                   "FILE_ALLOCATED_RANGE_BUFFER is not equivalent to pair<extent_type, extent_type>!");
@@ -398,10 +398,9 @@ result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexc
         return win32_error();
       }
     }
-    ret.resize(bytesout / sizeof(FILE_ALLOCATED_RANGE_BUFFER));
     return ret;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -410,7 +409,7 @@ result<std::vector<file_handle::extent_pair>> file_handle::extents() const noexc
 result<file_handle::extent_pair> file_handle::clone_extents_to(file_handle::extent_pair extent, byte_io_handle &dest_, byte_io_handle::extent_type destoffset,
                                                                deadline d, bool force_copy_now, bool emulate_if_unsupported) noexcept
 {
-  try
+  LLFIO_TRY
   {
     windows_nt_kernel::init();
     using namespace windows_nt_kernel;
@@ -840,7 +839,7 @@ result<file_handle::extent_pair> file_handle::clone_extents_to(file_handle::exte
     }
     return ret;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -885,7 +884,7 @@ result<file_handle::extent_type> file_handle::zero(file_handle::extent_pair exte
 
 LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fill_ios(const handle & /*unused*/, const std::string &mntfromname) noexcept
 {
-  try
+  LLFIO_TRY
   {
     alignas(8) wchar_t buffer[32769];
     // Firstly open a handle to the volume
@@ -978,7 +977,7 @@ LLFIO_HEADERS_ONLY_MEMFUNC_SPEC result<std::pair<uint32_t, float>> statfs_t::_fi
     iosbusytime /= disk_extents;
     return {iosinprogress, std::min(iosbusytime, 1.0f)};
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/windows/fs_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/fs_handle.ipp
@@ -49,7 +49,7 @@ result<path_handle> fs_handle::parent_path_handle(deadline d) const noexcept
   {
     OUTCOME_TRY(_fetch_inode());
   }
-  try
+  LLFIO_TRY
   {
     for(;;)
     {
@@ -123,7 +123,7 @@ result<path_handle> fs_handle::parent_path_handle(deadline d) const noexcept
       LLFIO_WIN_DEADLINE_TO_TIMEOUT_LOOP(d);
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }
@@ -335,12 +335,12 @@ result<void> fs_handle::unlink(deadline d) noexcept
     {
       // Rename it to something random to emulate immediate unlinking
       std::string randomname;
-      try
+      LLFIO_TRY
       {
         randomname = utils::random_string(32);
         randomname.append(".deleted");
       }
-      catch(...)
+      LLFIO_CATCH(...)
       {
         return error_from_exception();
       }
@@ -592,7 +592,7 @@ result<void> fs_handle::set_extended_attribute(path_view_component name, span<co
   the value will atomically update.
   */
   handle attribh;
-  try
+  LLFIO_TRY
   {
     for(;;)
     {
@@ -609,7 +609,7 @@ result<void> fs_handle::set_extended_attribute(path_view_component name, span<co
       }
     }
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/windows/handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/handle.ipp
@@ -50,7 +50,7 @@ handle::~handle()
 result<handle::path_type> handle::current_path() const noexcept
 {
   LLFIO_LOG_FUNCTION_CALL(this);
-  try
+  LLFIO_TRY
   {
     // Most efficient, least memory copying method is direct fill of a wstring which is moved into filesystem::path
     filesystem::path::string_type buffer;
@@ -73,7 +73,7 @@ result<handle::path_type> handle::current_path() const noexcept
     }
     return path_type(buffer);
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/windows/path_handle.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/path_handle.ipp
@@ -29,7 +29,7 @@ LLFIO_V2_NAMESPACE_BEGIN
 
 result<bool> path_handle::exists(path_view_type path) const noexcept
 {
-  try
+  LLFIO_TRY
   {
     windows_nt_kernel::init();
     using namespace windows_nt_kernel;
@@ -68,7 +68,7 @@ result<bool> path_handle::exists(path_view_type path) const noexcept
     }
     return true;
   }
-  catch(...)
+  LLFIO_CATCH(...)
   {
     return error_from_exception();
   }

--- a/include/llfio/v2.0/detail/impl/windows/storage_profile.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/storage_profile.ipp
@@ -52,7 +52,7 @@ namespace storage_profile
       }
       else
       {
-        try
+        LLFIO_TRY
         {
           using std::to_string;
           RTL_OSVERSIONINFOW ovi{};
@@ -76,7 +76,7 @@ namespace storage_profile
           os_name = sp.os_name.value;
           os_ver = sp.os_ver.value;
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }
@@ -99,7 +99,7 @@ namespace storage_profile
       }
       else
       {
-        try
+        LLFIO_TRY
         {
           SYSTEM_INFO si{};
           memset(&si, 0, sizeof(si));
@@ -193,7 +193,7 @@ namespace storage_profile
           cpu_architecture = sp.cpu_architecture.value;
           cpu_physical_cores = sp.cpu_physical_cores.value;
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }
@@ -221,7 +221,7 @@ namespace storage_profile
       // Controller type, max transfer, max buffers. Device name, size
       outcome<void> _device(storage_profile &sp, file_handle & /*unused*/, const std::string &_mntfromname, const std::string & /*fstypename*/) noexcept
       {
-        try
+        LLFIO_TRY
         {
           if(memcmp(_mntfromname.c_str(), "\\!!\\Device\\Mup", 14) == 0 || memcmp(_mntfromname.c_str(), "\\\\", 2) == 0)
           {
@@ -433,7 +433,7 @@ namespace storage_profile
             sp.device_size.value = dg->DiskSize.QuadPart;
           }
         }
-        catch(...)
+        LLFIO_CATCH(...)
         {
           return std::current_exception();
         }

--- a/include/llfio/v2.0/detail/impl/windows/test/iocp_multiplexer.ipp
+++ b/include/llfio/v2.0/detail/impl/windows/test/iocp_multiplexer.ipp
@@ -537,7 +537,7 @@ namespace test
 
   LLFIO_HEADERS_ONLY_FUNC_SPEC result<byte_io_multiplexer_ptr> multiplexer_win_iocp(size_t threads, bool disable_immediate_completions) noexcept
   {
-    try
+    LLFIO_TRY
     {
       if(1 == threads)
       {
@@ -549,7 +549,7 @@ namespace test
       OUTCOME_TRY(ret->init(threads, disable_immediate_completions));
       return ret;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/directory_handle.hpp
+++ b/include/llfio/v2.0/directory_handle.hpp
@@ -315,7 +315,7 @@ public:
   static inline result<directory_handle> uniquely_named_directory(const path_handle &dirpath, mode _mode = mode::write, caching _caching = caching::temporary,
                                                                   flag flags = flag::none) noexcept
   {
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -327,7 +327,7 @@ public:
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/file_handle.hpp
+++ b/include/llfio/v2.0/file_handle.hpp
@@ -175,7 +175,7 @@ public:
   static inline result<file_handle> uniquely_named_file(const path_handle &dirpath, mode _mode = mode::write, caching _caching = caching::temporary,
                                                         flag flags = flag::none) noexcept
   {
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -188,7 +188,7 @@ public:
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/map_handle.hpp
+++ b/include/llfio/v2.0/map_handle.hpp
@@ -952,7 +952,7 @@ namespace detail
 {
   inline result<byte_io_handle::registered_buffer_type> map_handle_allocate_registered_buffer(size_t &bytes) noexcept
   {
-    try
+    LLFIO_TRY
     {
       auto make_shared = [](map_handle h) -> byte_io_handle::registered_buffer_type
       {
@@ -1012,7 +1012,7 @@ namespace detail
       }
       return errc::not_enough_memory;
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -1199,7 +1199,7 @@ namespace detail
 {
   inline result<size_t> pagesize_from_flags(section_handle::flag _flag) noexcept
   {
-    try
+    LLFIO_TRY
     {
       const auto &pagesizes = utils::page_sizes();
       if((_flag & section_handle::flag::page_sizes_3) == section_handle::flag::page_sizes_3)
@@ -1228,7 +1228,7 @@ namespace detail
       }
       return pagesizes[0];
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/mapped_file_handle.hpp
+++ b/include/llfio/v2.0/mapped_file_handle.hpp
@@ -411,7 +411,7 @@ public:
                                                        creation _creation = creation::open_existing, caching _caching = caching::all, flag flags = flag::none,
                                                        section_handle::flag sflags = section_handle::flag::none, extent_type offset = 0) noexcept
   {
-    try
+    LLFIO_TRY
     {
       if(_mode == mode::append)
       {
@@ -437,7 +437,7 @@ public:
       }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -464,7 +464,7 @@ public:
                                                                       caching _caching = caching::temporary, flag flags = flag::none,
                                                                       section_handle::flag sflags = section_handle::flag::none) noexcept
   {
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -477,7 +477,7 @@ public:
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -522,14 +522,14 @@ public:
   mapped_temp_inode(size_type reservation = 0, const path_handle &dir = path_discovery::storage_backed_temporary_files_directory(), mode _mode = mode::write,
                     caching _caching = caching::temporary, flag flags = flag::none, section_handle::flag sflags = section_handle::flag::none) noexcept
   {
-    try
+    LLFIO_TRY
     {
       OUTCOME_TRY(auto &&v, file_handle::temp_inode(dir, _mode, _caching, flags));
       mapped_file_handle ret(std::move(v), sflags, 0);
       ret._reservation = reservation;
       return {std::move(ret)};
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }
@@ -622,12 +622,12 @@ public:
   result<mapped_file_handle> reopen(size_type reservation, extent_type offset = 0, mode mode_ = mode::unchanged, caching caching_ = caching::unchanged,
                                     deadline d = std::chrono::seconds(30)) const noexcept
   {
-    try
+    LLFIO_TRY
     {
       OUTCOME_TRY(auto &&fh, file_handle::reopen(mode_, caching_, d));
       return mapped_file_handle(std::move(fh), reservation, _sh.section_flags(), _offset + offset);
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/path_view.hpp
+++ b/include/llfio/v2.0/path_view.hpp
@@ -750,7 +750,7 @@ private:
 #else
     if(f != filesystem::path::format::auto_format)
     {
-      throw std::runtime_error("UTF-8 path conversion pre-C++20 cannot handle non-auto_format formatting.");
+      LLFIO_THROW std::runtime_error("UTF-8 path conversion pre-C++20 cannot handle non-auto_format formatting.");
     }
     return filesystem::u8path((const char *) v.data(), (const char *) v.data() + v.size());
 #endif
@@ -837,7 +837,7 @@ public:
 #ifdef LLFIO_USING_EXPERIMENTAL_FILESYSTEM
       if(formatting() == generic_format || formatting() == native_format)
       {
-        throw std::runtime_error("Path conversion with <experimental/filesystem> cannot handle generic_format or native_format formatting.");
+        LLFIO_THROW std::runtime_error("Path conversion with <experimental/filesystem> cannot handle generic_format or native_format formatting.");
       }
       return _path_from_char_array(v);
 #endif
@@ -3177,7 +3177,7 @@ namespace detail
       ret.assign(_.begin(), _.end());
     }
 #endif
-    template <class T> void operator()(span<T> /*unused*/) { throw std::logic_error("filesystem::path cannot be constructed from a byte input."); }
+    template <class T> void operator()(span<T> /*unused*/) { LLFIO_THROW std::logic_error("filesystem::path cannot be constructed from a byte input."); }
   };
 }  // namespace detail
 //! Append a path view component to a path view component

--- a/include/llfio/v2.0/pipe_handle.hpp
+++ b/include/llfio/v2.0/pipe_handle.hpp
@@ -232,7 +232,7 @@ public:
   static inline result<pipe_handle> random_pipe(mode _mode = mode::read, caching _caching = caching::all, flag flags = flag::unlink_on_first_close,
                                                 const path_handle &dirpath = path_discovery::temporary_named_pipes_directory()) noexcept
   {
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -245,7 +245,7 @@ public:
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/storage_profile.hpp
+++ b/include/llfio/v2.0/storage_profile.hpp
@@ -160,7 +160,7 @@ namespace storage_profile
       case storage_types::unknown:
         break;
       }
-      throw std::invalid_argument("No type set in item");  // NOLINT
+      LLFIO_THROW std::invalid_argument("No type set in item");  // NOLINT
     }
     //! Set this item if its value is default
     outcome<void> operator()(storage_profile &sp, handle_type &h) const

--- a/include/llfio/v2.0/symlink_handle.hpp
+++ b/include/llfio/v2.0/symlink_handle.hpp
@@ -466,7 +466,7 @@ public:
   LLFIO_MAKE_FREE_FUNCTION
   static inline result<symlink_handle> uniquely_named_symlink(const path_handle &dirpath, mode _mode = mode::write, flag flags = flag::none) noexcept
   {
-    try
+    LLFIO_TRY
     {
       for(;;)
       {
@@ -479,7 +479,7 @@ public:
         }
       }
     }
-    catch(...)
+    LLFIO_CATCH(...)
     {
       return error_from_exception();
     }

--- a/include/llfio/v2.0/utils.hpp
+++ b/include/llfio/v2.0/utils.hpp
@@ -409,12 +409,12 @@ namespace utils
     {
       if(n > max_size())
       {
-        throw std::bad_alloc();
+        LLFIO_THROW std::bad_alloc();
       }
       auto mem(detail::allocate_large_pages(n * sizeof(T)));
       if(mem.p == nullptr)
       {
-        throw std::bad_alloc();
+        LLFIO_THROW std::bad_alloc();
       }
       return reinterpret_cast<pointer>(mem.p);
     }
@@ -423,7 +423,7 @@ namespace utils
     {
       if(n > max_size())
       {
-        throw std::bad_alloc();
+        LLFIO_THROW std::bad_alloc();
       }
       detail::deallocate_large_pages(p, n * sizeof(T));
     }


### PR DESCRIPTION
This PR removes the need for exceptions to be enabled in llfio in a fairly basic way, and thus allows for `-fno-exceptions` builds. (This fixes #127). llfio's behavior should remain unchanged with this PR when exceptions are enabled.

However, with this PR, when c++ exceptions are disabled:
- The `NoValuePolicy` for llfio's `basic_result<T, E, NoValuePolicy>` type alias becomes [`policy::terminate`](https://ned14.github.io/outcome/reference/policies/terminate/). Thus, all wide `error()` calls terminate on failure instead of throwing exceptions. (`policy::terminate` was chosen so that llfio mimics the standard library behavior when exceptions are disabled)
- All try-catch blocks are "removed" using a macro. The try block always executes, while the catch block never does.
- `error_info::throw_exception()` just aborts.
- `error_from_exception(std::exception_ptr&&, std::error_code)` just returns an empty `error_info` (although it shouldn't actually ever be called).

There is a caveat, which is that with this solution, catch blocks which capture a specific exception **must now be passed by value**. This is because of how the new catch macro now declares the would-be caught exception as a variable so that the catch blocks still compile with exceptions disabled (even though they will never execute). 

To illustrate this, this example with exceptions enabled:
```cpp
catch (std::exception e) {
    std::string msg("path_discovery::verified_temporary_directories() saw exception thrown: ");
    msg.append(e.what());
    LLFIO_LOG_FATAL(nullptr, msg.c_str());
    abort();
}
```
turns into this with exceptions disabled:
```cpp
if (false); 
(std::exception e);
{
    std::string msg("path_discovery::verified_temporary_directories() saw exception thrown: ");
    msg.append(e.what());
    LLFIO_LOG_FATAL(nullptr, msg.c_str());
    abort();
}
```
If `e` was caught by const reference (i.e. declared as `const std::exception&`), this wouldn't compile when exceptions are disabled, as a const reference variable would be declared without an initializer.

So far, this only occurs in two instances, both in `include/llfio/v2.0/detail/impl/path_discovery.ipp`. While there is surely a better solution, this may be an acceptable drawback (although having to remember this for any future specific try/catch blocks will probably become annoying).

<br/>

On my local (linux) system, all tests within ctest pass except `llfio_sl--utils`, but I cannot determine if its failure is actually related to this PR or only related specifically to my local system. My own personal basic use-case test executable was successful and has the same behavior with or without this PR.