### PR TITLE
Fix system_code default argument in error_from_exception

### DIFF
--- a/include/llfio/v2.0/status_code.hpp
+++ b/include/llfio/v2.0/status_code.hpp
@@ -398,7 +398,7 @@ namespace detail
 }  // namespace detail
 inline file_io_error
 error_from_exception(std::exception_ptr &&ep = std::current_exception(),
-                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = errc::resource_unavailable_try_again) noexcept
+                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = SYSTEM_ERROR2_NAMESPACE::generic_code(errc::resource_unavailable_try_again)) noexcept
 {
 #ifdef __cpp_exceptions
   return SYSTEM_ERROR2_NAMESPACE::system_code_from_exception(


### PR DESCRIPTION
This cast is necessary to build on Visual Studio 2026 18.6.0 / MSVC 19.51 when `llfio[status-code]` is turned on

```console
C:\Dev\vcpkg2\buildtrees\llfio\src\20260506-b0cb791d93.clean\include\llfio\v2.0\status_code.hpp(401,79): error C2440: 'default argument': cannot convert from 'system_error2::errc' to 'system_error2::system_code'
                     SYSTEM_ERROR2_NAMESPACE::system_code not_matched = errc::resource_unavailable_try_again) noexcept
                                                                              ^
C:\Dev\vcpkg2\buildtrees\llfio\src\20260506-b0cb791d93.clean\include\llfio\v2.0\status_code.hpp(401,79): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
```

I'm not sure exactly why the implicit conversion isn't working on the default argument here :/