### PR TITLE
Fix MSVC container-of-move-only-type workaround in algorithm::traverse

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ library originally for the C++ standard, intended for storage devices with ~1 mi
 4Kb transfer latencies and those supporting Storage Class Memory (SCM)/Direct Access
 Storage (DAX). Its i/o overhead, including syscall overhead, has been benchmarked to
 100 nanoseconds on Linux which corresponds to a theoretical maximum of 10M IOPS @ QD1,
-approx 40Gb/sec per thread. It has particularly strong support for writing portable
+approx 40GB/sec per thread. It has particularly strong support for writing portable
 filesystem algorithms which work well with directly mapped non-volatile storage such
 as Intel Optane.
 
@@ -191,9 +191,9 @@ Manufacturer claimed 4Kb transfer latencies for the physical hardware:
 </table>
 
 Max bandwidth for the physical hardware:
-- DDR4 2133: **30Gb/sec** (main memory)
-- x4 PCIe 4.0: **7.5Gb/sec** (arrives end of 2017, the 2018 NVMe drives will use PCIe 4.0)
-- x4 PCIe 3.0: **3.75Gb/sec** (985Mb/sec per PCIe lane)
-- 2017 XPoint drive (x4 PCIe 3.0): **2.5Gb/sec**
-- 2017 NVMe flash drive (x4 PCIe 3.0): **2Gb/sec**
-- 10Gbit LAN: **1.2Gb/sec**
+- DDR4 2133: **30GB/sec** (main memory)
+- x4 PCIe 4.0: **7.5GB/sec** (arrives end of 2017, the 2018 NVMe drives will use PCIe 4.0)
+- x4 PCIe 3.0: **3.75GB/sec** (985MB/sec per PCIe lane)
+- 2017 XPoint drive (x4 PCIe 3.0): **2.5GB/sec**
+- 2017 NVMe flash drive (x4 PCIe 3.0): **2GB/sec**
+- 10Gbit LAN: **1.2GB/sec**

--- a/include/llfio/v2.0/detail/impl/traverse.ipp
+++ b/include/llfio/v2.0/detail/impl/traverse.ipp
@@ -164,7 +164,7 @@ namespace algorithm
                 using_sso = true;
               }
             }
-#if _MSVC_STL_VERSION < 150  // see ned14/llfio#98
+#if defined(_MSC_VER)  // see ned14/llfio#98
             workitem(const workitem &o) noexcept
                 : workitem(const_cast<workitem &&>(std::move(o)))
             {


### PR DESCRIPTION
## Summary
The workaround for the MSVC STL defect where `vector<list<move-only-type>>` doesn't compile was gated on `_MSVC_STL_VERSION < 150`, but the underlying standard defect (see microsoft/STL#1036) affects all current MSVC versions. This broadens the check to cover any MSC compiler.

## Changes
- `include/llfio/v2.0/detail/impl/traverse.ipp`: Change `#if _MSVC_STL_VERSION < 150` to `#if defined(_MSC_VER)` so the moving copy constructor workaround applies to all MSVC versions

Closes: #98