### PR TITLE
path_view: guard char8_t->wchar_t locale codecvt for libc++

### DIFF
--- a/include/llfio/v2.0/detail/impl/path_view.ipp
+++ b/include/llfio/v2.0/detail/impl/path_view.ipp
@@ -234,6 +234,12 @@ namespace detail
     }
     else
     {
+#if defined(_LIBCPP_VERSION)
+      // libc++ does not ship a std::codecvt<char8_t, wchar_t, mbstate_t> specialization.
+      (void) loc;
+      LLFIO_LOG_FATAL(nullptr, "path_view_component::rendered_path reencoding function does not support char8_t to wchar_t conversion with a custom locale on libc++.");
+      abort();
+#else
       auto &convert = std::use_facet<_codecvt<char8_t, wchar_t>>(*loc);
       std::mbstate_t cstate{};
       written = (DWORD)(src_buffer_length * convert.max_length() * sizeof(wchar_t));
@@ -266,6 +272,7 @@ namespace detail
         LLFIO_EXCEPTION_THROW(std::system_error(make_error_code(std::errc::no_buffer_space)));
       }
       state.buffer.Length = (USHORT) written;
+#endif
     }
     // Do any / to \ conversion now
     for(size_t n = 0; n < state.buffer.Length / sizeof(wchar_t); n++)


### PR DESCRIPTION
## Summary
- libc++ does not provide a `std::codecvt<char8_t, wchar_t, std::mbstate_t>` specialization.
- The locale-driven `else` branch of `reencode_path_to(char*, ..., const char8_t*, ..., const std::locale*)` in `path_view.ipp` instantiates `_codecvt<char8_t, wchar_t>` (which derives from that absent specialization), so the file fails to compile on Windows targets that use libc++ — e.g. msys2 `clang64` mingw and clang/Windows.
- Wrap that branch with the same `#if defined(_LIBCPP_VERSION)` abort() pattern already used by the sibling `reencode_path_to(wchar_t*, ..., const char8_t*, ...)` overload (around lines 467+).

## Build error this fixes
```
include/llfio/v2.0/detail/impl/path_view.ipp:43:61: error:
  implicit instantiation of undefined template
  'std::codecvt<char8_t, wchar_t, _Mbstatet>'
include/llfio/v2.0/detail/impl/path_view.ipp:251:15: error:
  no member named 'out' in 'llfio_v2_...::detail::_codecvt<char8_t, wchar_t>'
```

## Test plan
- [x] msys2 clang64 mingw: builds clean with this patch (verified on downstream CI)
- [x] msys2 ucrt64 (libstdc++): still passes (unchanged path)
- [x] msys2 mingw64 (libstdc++): still passes (unchanged path)
- [x] MSVC: unchanged path, behavior identical